### PR TITLE
Add benchmark integration scripts for Wisent-Guard

### DIFF
--- a/generate_all_prompts.py
+++ b/generate_all_prompts.py
@@ -1,0 +1,17 @@
+# Integrated with Wisent-Guard v1.
+
+import subprocess
+
+tasks = [
+    "truthfulqa_mc1",
+    "winogrande",
+    "wsc",
+    "piqa",
+    "tmmluplus_physics",
+    "tmmluplus_finance_banking"
+]
+
+for task in tasks:
+    output_file = f"{task}_prompts.json"
+    print(f"Extracting {task} -> {output_file}")
+    subprocess.run(["python", "-m", "lm_eval.extract_prompt_target", task, output_file])

--- a/predict_with_classifier.py
+++ b/predict_with_classifier.py
@@ -1,0 +1,21 @@
+# Integrated with Wisent-Guard v1.
+import joblib
+
+def predict(text):
+    # Load the entire pipeline (vectorizer + classifier)
+    pipeline = joblib.load("classifier_pipeline.joblib")
+    
+    # Predict label
+    prediction = pipeline.predict([text])[0]
+    
+    # Convert numeric label to readable text
+    label = "Truthful" if prediction == 1 else "Hallucination"
+    print(f"Prediction: {label}")
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 2:
+        print("Usage: python predict_with_classifier.py '<your_text_here>'")
+    else:
+        text = sys.argv[1]
+        predict(text)

--- a/prepare_classifier_data.py
+++ b/prepare_classifier_data.py
@@ -1,0 +1,20 @@
+# Integrated with Wisent-Guard v1.
+import json
+import glob
+
+examples = []
+
+for filename in glob.glob("*_prompts.json"):
+    with open(filename) as f:
+        data = json.load(f)
+
+        for item in data:
+            if "text" in item and "label" in item:
+                examples.append(item)
+
+print(f"Loaded {len(examples)} examples total.")
+
+with open("classifier_data.json", "w") as f:
+    json.dump(examples, f, indent=2)
+
+print("Saved to classifier_data.json")

--- a/train_classifier.py
+++ b/train_classifier.py
@@ -1,0 +1,31 @@
+# Integrated with Wisent-Guard v1.
+import json
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import make_pipeline
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import classification_report
+import joblib
+
+with open("final_training_data.json") as f:
+    data = json.load(f)
+
+texts = [item["text"] for item in data]
+labels = [item["label"] for item in data]
+
+X_train, X_test, y_train, y_test = train_test_split(
+    texts, labels, test_size=0.2, random_state=42, stratify=labels
+)
+
+pipeline = make_pipeline(
+    TfidfVectorizer(),
+    LogisticRegression(max_iter=1000, class_weight="balanced")
+)
+
+pipeline.fit(X_train, y_train)
+
+y_pred = pipeline.predict(X_test)
+print(classification_report(y_test, y_pred))
+
+joblib.dump(pipeline, "classifier_pipeline.joblib")
+print("Classifier pipeline saved to classifier_pipeline.joblib")


### PR DESCRIPTION
This PR adds initial scripts to support benchmark-based evaluation inside Wisent-Guard.

Included:
- `generate_all_prompts.py` – extracts prompt/target pairs from several lm-eval-harness-compatible benchmarks
- `prepare_classifier_data.py` – formats positive/negative samples for training hallucination classifier
- `train_classifier.py` – trains the classifier based on benchmark-derived data
- `predict_with_classifier.py` – runs inference and logs classifier decisions

These scripts are adapted from a working lm-eval-harness integration and can be refactored into CLI or internal modules as needed.

Let me know if you'd prefer them integrated directly into `wisent_guard/` or as standalone examples first.

Looking forward to your feedback!