### PR TITLE
Add landing-cli inputs

### DIFF
--- a/landing.brief.json
+++ b/landing.brief.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": 1,
+  "product": "Ster",
+  "audience": "Developers and researchers working with local open-weight language models who need to read representations, learn measured directions, and steer generation.",
+  "problem": "Representation work often crosses opaque framework boundaries, making it difficult to bind a learned direction to the exact model, layer, width, method, and intervention point where it is valid.",
+  "promise": "A native Rust path from contrastive examples and hidden states to measured steering artifacts and controlled generation.",
+  "primaryAction": {
+    "label": "Read the workflow",
+    "kind": "url",
+    "target": "https://github.com/wisent-ai/ster#first-steering-workflow"
+  },
+  "secondaryAction": {
+    "label": "Inspect the source",
+    "purpose": "Review the native runtime, CLI, and versioned artifact contract.",
+    "target": "https://github.com/wisent-ai/ster"
+  },
+  "approvedClaims": [
+    {
+      "claim": "Ster is a native Rust toolkit for representation reading and activation steering in open-weight language models.",
+      "evidence": "README.md#Ster"
+    },
+    {
+      "claim": "Ster reads last-token hidden states from selected transformer layers, learns directions from contrastive examples, evaluates them, and applies them during generation.",
+      "evidence": "README.md#Ster; README.md#Current product contract"
+    },
+    {
+      "claim": "Ster 0.12 provides one binary and one library crate using the same versioned JSON artifacts and native Candle runtime.",
+      "evidence": "README.md#Current product contract"
+    },
+    {
+      "claim": "The current runtime supports local and Hugging Face Llama-family Safetensors checkpoints on CPU, with compile-time Metal and CUDA backends.",
+      "evidence": "README.md#Current product contract"
+    },
+    {
+      "claim": "Ster supports CAA, PCA, and logistic-probe training plus holdout selection across method and layer.",
+      "evidence": "README.md#Current product contract"
+    },
+    {
+      "claim": "Ster evaluates artifacts with pair-ordering accuracy and projection margin before additive residual-stream steering during autoregressive generation.",
+      "evidence": "README.md#Current product contract"
+    },
+    {
+      "claim": "Every steering artifact records product and schema identity, model revision, trait, method, hidden width, layer-indexed directions, training accuracy, and projection margin.",
+      "evidence": "README.md#Artifact contract"
+    },
+    {
+      "claim": "Ster refuses artifacts with the wrong product, schema, model, or vector width instead of applying them to the wrong residual stream.",
+      "evidence": "README.md#Artifact contract"
+    },
+    {
+      "claim": "Ster owns its Llama decoder loop so it can capture a residual state after a selected block and add a direction before the next block.",
+      "evidence": "README.md#Architecture"
+    },
+    {
+      "claim": "Ster controls local open-weight models; hosted model routing, fleet placement, credentials, and release delivery belong to other products.",
+      "evidence": "README.md#Current product contract"
+    }
+  ],
+  "requiredProof": [
+    "The documented train and generate commands from the first steering workflow.",
+    "The six native CLI operations: train, optimize, evaluate, generate, extract, and inspect.",
+    "The versioned artifact fields and the product, schema, model, and vector-width refusal boundary.",
+    "The exact residual capture and addition points in the native Candle decoder loop."
+  ],
+  "brand": {
+    "canonicalAssets": [
+      "assets/readme-banner.webp",
+      "assets/readme-banner.svg"
+    ],
+    "rules": [
+      "Use the canonical Wisent type, color, spacing, radius, and motion tokens.",
+      "Keep representation, artifact, and intervention language technically precise.",
+      "Use one primary action and concrete source-backed workflow evidence."
+    ],
+    "forbidden": [
+      "Invented benchmark results, accuracy figures, performance claims, or supported model families.",
+      "Claims that Ster routes hosted models, manages fleets, or owns credentials.",
+      "Python package or wisent command compatibility claims.",
+      "Fake terminal output, fake artifacts, generic AI gradients, or glass cards."
+    ]
+  },
+  "analyticsOwner": "Wisent product and design maintainers",
+  "notes": [
+    "Preserve the current landing's approved read, learn, measure, and steer positioning only where the canonical README supports it.",
+    "Ster is the product; Wisent is the company."
+  ]
+}

--- a/landing.config.json
+++ b/landing.config.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": 1,
+  "siteName": "Ster",
+  "domain": "https://ster.wisent.com",
+  "repository": "https://github.com/wisent-ai/ster",
+  "sourceUrl": "https://github.com/wisent-ai/ster",
+  "docsUrl": "https://github.com/wisent-ai/ster#readme",
+  "discordUrl": "https://discord.gg/qRjpkthq54",
+  "ogImageAlt": "Ster by Wisent — native representation reading and activation steering",
+  "navLinks": [
+    { "label": "Workflow", "href": "https://github.com/wisent-ai/ster#first-steering-workflow" },
+    { "label": "Artifacts", "href": "https://github.com/wisent-ai/ster#artifact-contract" },
+    { "label": "Source", "href": "https://github.com/wisent-ai/ster" },
+    { "label": "Discord", "href": "https://discord.gg/qRjpkthq54" }
+  ],
+  "footerLinks": [
+    { "label": "Current contract", "href": "https://github.com/wisent-ai/ster#current-product-contract" },
+    { "label": "Install", "href": "https://github.com/wisent-ai/ster#install" },
+    { "label": "CLI", "href": "https://github.com/wisent-ai/ster#cli" },
+    { "label": "Architecture", "href": "https://github.com/wisent-ai/ster#architecture" },
+    { "label": "Source", "href": "https://github.com/wisent-ai/ster" },
+    { "label": "Discord", "href": "https://discord.gg/qRjpkthq54" },
+    { "label": "Wisent", "href": "https://wisent.com" },
+    { "label": "License (MIT)", "href": "https://github.com/wisent-ai/ster/blob/main/LICENSE" }
+  ]
+}

--- a/landing.plan.json
+++ b/landing.plan.json
@@ -1,0 +1,204 @@
+{
+  "schemaVersion": 1,
+  "hero": {
+    "eyebrow": "Ster by Wisent",
+    "headline": "Read, learn, measure, and steer open-weight models in Rust",
+    "metaDescription": "Ster is a native Rust toolkit for representation reading and activation steering in local open-weight language models.",
+    "lede": "Ster is a native Rust toolkit for reading last-token hidden states, learning directions from contrastive examples, evaluating them, and applying measured interventions during generation.",
+    "proofStrip": [
+      "Native Rust toolkit",
+      "Reads last-token states",
+      "CAA, PCA, logistic probes",
+      "Width mismatch refused"
+    ]
+  },
+  "sections": [
+    {
+      "kind": "recognition",
+      "id": "directions-need-bindings",
+      "heading": "A direction is only valid inside its exact boundary",
+      "lede": "Representation work breaks when model, layer, width, method, and intervention point drift apart.",
+      "claimRefs": [
+        1,
+        6,
+        7,
+        8
+      ],
+      "items": [
+        {
+          "title": "Layer and width must stay explicit",
+          "text": "Ster reads last-token hidden states from selected transformer layers and records hidden width in the artifact."
+        },
+        {
+          "title": "Method must travel with the vector",
+          "text": "Artifacts record trait, method, layer-indexed directions, training accuracy, and projection margin."
+        },
+        {
+          "title": "The wrong stream is refused",
+          "text": "Ster refuses artifacts with the wrong product, schema, model, or vector width instead of applying them."
+        }
+      ]
+    },
+    {
+      "kind": "mechanism",
+      "id": "from-examples-to-steering",
+      "heading": "One path from contrastive examples to controlled generation",
+      "lede": "The workflow stays inside one native Rust binary and library crate with versioned JSON artifacts.",
+      "claimRefs": [
+        1,
+        2,
+        4,
+        5,
+        8
+      ],
+      "items": [
+        {
+          "step": "01",
+          "title": "Read",
+          "text": "Ster reads last-token hidden states from selected transformer layers."
+        },
+        {
+          "step": "02",
+          "title": "Learn",
+          "text": "Ster learns directions from contrastive examples with CAA, PCA, or logistic-probe training."
+        },
+        {
+          "step": "03",
+          "title": "Measure",
+          "text": "Ster evaluates artifacts with pair-ordering accuracy and projection margin, with holdout selection across method and layer."
+        },
+        {
+          "step": "04",
+          "title": "Steer",
+          "text": "Ster adds a measured direction in the residual stream during autoregressive generation."
+        }
+      ]
+    },
+    {
+      "kind": "proof",
+      "id": "six-native-operations",
+      "heading": "Six native operations carry the workflow",
+      "lede": "One binary and one library crate share the same versioned JSON artifacts and native Candle runtime.",
+      "claimRefs": [
+        1,
+        2,
+        4,
+        5
+      ],
+      "artifact": {
+        "type": "table",
+        "caption": "The six native CLI operations named by the required proof.",
+        "columns": [
+          "Operation",
+          "Role in workflow"
+        ],
+        "rows": [
+          [
+            "train",
+            "Learn directions from examples"
+          ],
+          [
+            "optimize",
+            "Select across method and layer"
+          ],
+          [
+            "evaluate",
+            "Score ordering and margin"
+          ],
+          [
+            "generate",
+            "Apply steering during decoding"
+          ],
+          [
+            "extract",
+            "Read selected hidden states"
+          ],
+          [
+            "inspect",
+            "Read recorded fields"
+          ]
+        ]
+      }
+    },
+    {
+      "kind": "proof",
+      "id": "artifact-refusal-boundary",
+      "heading": "The artifact contract refuses the wrong residual stream",
+      "lede": "Every steering artifact records identity and measurement fields before generation uses it.",
+      "claimRefs": [
+        6,
+        7
+      ],
+      "artifact": {
+        "type": "table",
+        "caption": "Versioned artifact fields and the refusal boundary defined by the artifact contract.",
+        "columns": [
+          "Artifact field",
+          "Boundary"
+        ],
+        "rows": [
+          [
+            "Product identity",
+            "Wrong product refused"
+          ],
+          [
+            "Schema identity",
+            "Wrong schema refused"
+          ],
+          [
+            "Model revision",
+            "Wrong model refused"
+          ],
+          [
+            "Hidden width",
+            "Wrong width refused"
+          ],
+          [
+            "Method and trait",
+            "Kept with directions"
+          ],
+          [
+            "Accuracy and margin",
+            "Recorded before steering"
+          ]
+        ]
+      }
+    },
+    {
+      "kind": "objection",
+      "id": "boundaries-before-adoption",
+      "heading": "Adoption questions answered by the contract",
+      "claimRefs": [
+        3,
+        7,
+        9
+      ],
+      "items": [
+        {
+          "question": "Does Ster route hosted models or manage fleets?",
+          "answer": "No. Ster controls local open-weight models; hosted routing, fleet placement, credentials, and release delivery belong to other products."
+        },
+        {
+          "question": "What checkpoints can the current runtime use?",
+          "answer": "The runtime supports local and Hugging Face Llama-family Safetensors checkpoints on CPU, with compile-time Metal and CUDA backends."
+        },
+        {
+          "question": "What stops a vector from the wrong model being applied?",
+          "answer": "Ster refuses artifacts with the wrong product, schema, model, or vector width instead of applying them to the wrong residual stream."
+        }
+      ]
+    },
+    {
+      "kind": "decision",
+      "id": "read-the-workflow",
+      "heading": "Start with the documented first steering workflow",
+      "lede": "Use Ster when you need a native Rust path from hidden states and contrastive examples to measured artifacts and controlled generation, with refusal at the artifact boundary.",
+      "claimRefs": [
+        0,
+        1,
+        2,
+        7
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds source-backed approved claims, site config, frozen 50-reference context, component decisions, and the Brama-authored content plan. Tests were not run per instruction.